### PR TITLE
SwapHands event

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 group = 'net.moddedminecraft'
-version = '1.7.1-API-7'
+version = '1.7.2-API-7'
 
 description = """MMCRestrict"""
 

--- a/src/main/java/net/moddedminecraft/mmcrestrict/EventListener.java
+++ b/src/main/java/net/moddedminecraft/mmcrestrict/EventListener.java
@@ -325,6 +325,23 @@ public class EventListener {
     }
 
     @Listener
+    public void onSwapHand(ChangeInventoryEvent.SwapHand event, @Root Player player){
+        if (player.hasPermission(Permissions.ITEM_BYPASS)){
+            return;
+        }
+        for (SlotTransaction transaction : event.getTransactions()) {
+            ItemStack itemStack = transaction.getFinal().createStack();
+            if (itemStack.getType().equals(ItemTypes.NONE)) {
+                continue;
+            }
+
+            if (checkBanned(itemStack, "own", player)){
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @Listener
     public void onClickInventoryEvent(ClickInventoryEvent event, @Root Player player) {
         if (player.hasPermission(Permissions.ITEM_BYPASS)) {
             return;

--- a/src/main/java/net/moddedminecraft/mmcrestrict/Main.java
+++ b/src/main/java/net/moddedminecraft/mmcrestrict/Main.java
@@ -46,7 +46,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-@Plugin(id = "mmcrestrict", name = "MMCRestrict", version = "1.7.1", description = "A simple item restriction plugin", authors = {"Leelawd93"})
+@Plugin(id = "mmcrestrict", name = "MMCRestrict", version = "1.7.2", description = "A simple item restriction plugin", authors = {"Leelawd93"})
 public class Main {
 
     private static Main instance;


### PR DESCRIPTION
Fixed an exploit where players could get an item in their offhand and swap it to their mainhand by adding a listener for the event and canceling it.